### PR TITLE
Test multipart CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,10 @@ jobs:
             fi
       - store_artifacts:
           path: dist
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
 
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,10 +119,13 @@ workflows:
       - tests:
           requires:
             - install
+      - build:
+          requires:
+            - test
+            - lint
       - publish:
           requires:
-            - tests
-            - lint
+            - build
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,16 @@ jobs:
       - run:
           name: Install python dependencies
           command: |
+            poetry config virtualenvs.in-project true
             poetry install
       - save_cache:
           key: py-cache-{{ arch }}-{{ checksum "poetry.lock" }}
           paths:
-            - /home/circleci/.cache/pypoetry/virtualenvs
+            - .venv
       - save_cache:
           key: py-cache-{{ arch }}-{{ .Branch }}
           paths:
-            - /home/circleci/.cache/pypoetry/virtualenvs
+            - .venv
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 parameters:
   python-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,6 @@ workflows:
           filters:
             branches:
               only:
-                # FIXME: remove
-                - ci-workflow
                 - master
                 - /[0-9]+(\.[0-9]+)+/
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ workflows:
             - install
       - build:
           requires:
-            - test
+            - tests
             - lint
       - publish:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,8 @@ workflows:
           filters:
             branches:
               only:
+                # FIXME: remove
+                - ci-workflow
                 - master
                 - /[0-9]+(\.[0-9]+)+/
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,10 @@ jobs:
           key: py-cache-{{ arch }}-{{ .Branch }}
           paths:
             - /home/circleci/.cache/pypoetry/virtualenvs
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
 
   lint:
     docker:
@@ -44,11 +48,7 @@ jobs:
           at: .
       - run:
           name: Lint code
-          command: |
-            pip
-            poetry run flake8 << pipeline.parameters.python-module >>
-      - store_artifacts:
-          path: dist
+          command: poetry run flake8 << pipeline.parameters.python-module >>
 
   tests:
     docker:
@@ -70,10 +70,6 @@ jobs:
             poetry run pytest --junitxml=reports/python/tests.xml -p no:sugar --color=yes
       - store_test_results:
           path: reports/python
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
 
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,18 @@
 ---
 version: 2
 
+parameters:
+  python-version:
+    type: string
+    default: "3.9"
+  python-module:
+    type: string
+    default: "udata_hydra"
+
 jobs:
-  build:
+  install:
     docker:
-      - image: cimg/python:3.9.2
-      - image: cimg/postgres:11.15
-        environment:
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+      - image: cimg/python:<< pipeline.parameters.python-version >>
     steps:
       - checkout
       - run:
@@ -32,6 +35,32 @@ jobs:
           key: py-cache-{{ arch }}-{{ .Branch }}
           paths:
             - /home/circleci/.cache/pypoetry/virtualenvs
+
+  lint:
+    docker:
+      - image: cimg/python:<< pipeline.parameters.python-version >>
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint code
+          command: |
+            pip
+            poetry run flake8 << pipeline.parameters.python-module >>
+      - store_artifacts:
+          path: dist
+
+  tests:
+    docker:
+      - image: cimg/python:<< pipeline.parameters.python-version >>
+      - image: cimg/postgres:11.15
+        environment:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+    steps:
+      - attach_workspace:
+          at: .
       - run:
           name: Run tests
           environment:
@@ -41,6 +70,17 @@ jobs:
             poetry run pytest --junitxml=reports/python/tests.xml -p no:sugar --color=yes
       - store_test_results:
           path: reports/python
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  build:
+    docker:
+      - image: cimg/python:<< pipeline.parameters.python-version >>
+    steps:
+      - attach_workspace:
+          at: .
       - run:
           name: Build a distributable package
           command: |
@@ -55,14 +95,10 @@ jobs:
             fi
       - store_artifacts:
           path: dist
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
 
   publish:
     docker:
-      - image: cimg/python:3.9.2
+      - image: cimg/python:<< pipeline.parameters.python-version >>
     steps:
       - attach_workspace:
           at: .
@@ -75,13 +111,17 @@ workflows:
   version: 2
   build:
     jobs:
-      - build:
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+      - install
+      - lint:
+          requires:
+            - install
+      - tests:
+          requires:
+            - install
       - publish:
           requires:
-            - build
+            - tests
+            - lint
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - dist
+            - .
 
   publish:
     docker:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 100
+max-line-length = 120

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import csv
 import os
@@ -6,7 +7,6 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import aiohttp
-import asyncio
 import asyncpg
 import boto3
 from botocore.client import Config
@@ -18,13 +18,13 @@ from progressist import ProgressBar
 
 from udata_event_service.consumer import consume_kafka
 
-log = logging.getLogger("udata-hydra")
-log.setLevel(os.getenv("LOGLEVEL", logging.INFO))
-logging.basicConfig()
-
 from udata_hydra.config import KAFKA_URI
 from udata_hydra.kafka.consumer import process_message
 from udata_hydra.utils.kafka import get_topic
+
+log = logging.getLogger("udata-hydra")
+log.setLevel(os.getenv("LOGLEVEL", logging.INFO))
+logging.basicConfig()
 
 CATALOG_URL = 'https://www.data.gouv.fr/fr/datasets/r/4babf5f2-6a9c-45b5-9144-ca5eae6a7a6d'
 
@@ -224,7 +224,9 @@ def run_kafka_integration() -> None:
     consume_kafka(
         kafka_uri=KAFKA_URI,
         group_id="datalake",
-        topics=[get_topic(topic_suffix) for topic_suffix in ["resource.created", "resource.modified", "resource.deleted"]],
+        topics=[get_topic(topic_suffix) for topic_suffix in [
+            "resource.created", "resource.modified", "resource.deleted"
+        ]],
         message_processing_func=run_process_message,
     )
 

--- a/udata_hydra/kafka/consumer.py
+++ b/udata_hydra/kafka/consumer.py
@@ -42,4 +42,3 @@ async def process_message(key: str, message: dict, topic: str) -> None:
             await connection.execute(q)
         else:
             log.error(f"Unknown topic {topic}")
-

--- a/udata_hydra/utils/csv.py
+++ b/udata_hydra/utils/csv.py
@@ -9,6 +9,7 @@ def find_delimiter(filename):
         delimiter = sniffer.sniff(fp.read(5000), delimiters=';,|\t').delimiter
     return delimiter
 
+
 def detect_encoding(the_file):
     '''Detects file encoding using chardet based on N first lines
     '''


### PR DESCRIPTION
Ultimate CI bike shedding (or yake shaving?) ☢️ 

Before working on a template, I wanted to test a few things on a real workflow, hence this PR.

This splits the CI workflow into multiples small steps (and adds linting in this case) rather than a big build and a small publish.

Plus side:
- I like the way the feedback is available: you know at a glance which step failed, either from Github or from Circle
- It provides a framework for more complex CI workflows (parallel task for example, here the linting is parallelized which is not very useful but still)
- Variables are cool

Minus:
- More lines in file — not sure if easier or harder to grasp
- There must be some overhead of spinning up multiple jobs instead of one, but it seems minor

<img width="612" alt="Capture d’écran 2022-08-25 à 12 11 10" src="https://user-images.githubusercontent.com/119625/186641623-96ff964f-d45b-4ced-88b8-77daa26e8a2b.png">

<img width="804" alt="Capture d’écran 2022-08-25 à 11 50 03" src="https://user-images.githubusercontent.com/119625/186641672-e8c91a33-b1bc-417c-a973-bc8754bf9c61.png">

<img width="1172" alt="Capture d’écran 2022-08-25 à 12 28 38" src="https://user-images.githubusercontent.com/119625/186641762-4784561a-d31a-49d0-9927-50df3ebbd076.png">
