### PR TITLE
Check by resource_id

### DIFF
--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -59,6 +59,7 @@ async def init_db(drop=False, table=None, index=False, reindex=False):
         """
         CREATE TABLE IF NOT EXISTS checks(
             id serial PRIMARY KEY,
+            resource_id UUID,
             url VARCHAR,
             domain VARCHAR,
             created_at TIMESTAMP DEFAULT NOW(),

--- a/udata_hydra/crawl.py
+++ b/udata_hydra/crawl.py
@@ -127,7 +127,8 @@ async def update_check_and_catalog(check_data: dict) -> None:
         log.debug("Updating priority...")
         await connection.execute(
             f"""
-            UPDATE catalog SET priority = FALSE, initialization = FALSE WHERE resource_id = '{check_data['resource_id']}';
+            UPDATE catalog SET priority = FALSE, initialization = FALSE
+            WHERE resource_id = '{check_data['resource_id']}';
         """
         )
 

--- a/udata_hydra/crawl.py
+++ b/udata_hydra/crawl.py
@@ -6,6 +6,7 @@ import time
 
 from collections import defaultdict
 from datetime import datetime, timedelta
+from requests.exceptions import SSLError
 from urllib.parse import urlparse
 
 import aiohttp
@@ -249,7 +250,12 @@ async def check_url(row, session, sleep=0, method="get"):
     # assert port is not None
     # UnicodeError: encoding with 'idna' codec failed (UnicodeError: label too long)
     # eg http://%20Localisation%20des%20acc%C3%A8s%20des%20offices%20de%20tourisme
-    except Exception as e:
+    except (
+        aiohttp.client_exceptions.ClientError,
+        AssertionError,
+        UnicodeError,
+        SSLError,
+    ) as e:
         error = getattr(e, "message", None) or str(e)
         await update_check_and_catalog(
             {


### PR DESCRIPTION
Instead of checking if the status has changed for the same URL we check for the same resource_id, so as to send a Kafka message whenever the resource availability has changed, regardless whether the URL was checked before for a different resource.

Fix https://github.com/etalab/udata-hydra/issues/19.