### PR TITLE
Remove csv_analysis, integrate into checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Use profiling option from csv-detective [#54](https://github.com/etalab/udata-hydra/pull/54)
 - Add new types for csv parsing: json, date and datetime [#51](https://github.com/etalab/udata-hydra/pull/51)
 - Notify udata of csv parsing [#51](https://github.com/etalab/udata-hydra/pull/51)
 - Allow `None` values in udata notifications [#51](https://github.com/etalab/udata-hydra/pull/51)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Use profiling option from csv-detective [#54](https://github.com/etalab/udata-hydra/pull/54)
+- Remove csv_analysis, integrate into checks [#52](https://github.com/etalab/udata-hydra/pull/52)
 - Add new types for csv parsing: json, date and datetime [#51](https://github.com/etalab/udata-hydra/pull/51)
 - Notify udata of csv parsing [#51](https://github.com/etalab/udata-hydra/pull/51)
 - Allow `None` values in udata notifications [#51](https://github.com/etalab/udata-hydra/pull/51)

--- a/poetry.lock
+++ b/poetry.lock
@@ -397,18 +397,6 @@ files = [
 ]
 
 [[package]]
-name = "chardet"
-version = "5.1.0"
-description = "Universal encoding detector for Python 3"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "chardet-5.1.0-py3-none-any.whl", hash = "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"},
-    {file = "chardet-5.1.0.tar.gz", hash = "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5"},
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -470,24 +458,20 @@ cron = ["capturer (>=2.4)"]
 
 [[package]]
 name = "csv-detective"
-version = "0.4.7"
+version = "0.6.2"
 description = "Detect CSV column content"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "csv_detective-0.4.7.tar.gz", hash = "sha256:8bbe44bfd2241c9cb01e25174297f71b0a0df1d9e99d9023c561338fb7ab315c"},
+    {file = "csv_detective-0.6.2-py3-none-any.whl", hash = "sha256:98c2ec702ee7c8a04d90ed64e4589e1e02ca00b2efae2e1be5e445deeff41ff7"},
 ]
 
 [package.dependencies]
 boto3 = ">=1.21.21"
 cchardet = "*"
-chardet = ">=3.0"
 pandas = ">=0.20"
 unidecode = ">=0.4"
-
-[package.extras]
-test = ["nose"]
 
 [[package]]
 name = "dateparser"
@@ -1781,4 +1765,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e21d5cc18bbdecaab120785931da7806d179045ca18146a595885a5ebdc342b4"
+content-hash = "634c188b837ad53f0de11c1d009775360b887c58c216d8a66739bd7233ff2237"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ str2bool = "^1.1"
 sqlalchemy = "^1.4.46"
 dateparser = "^1.1.7"
 python-dateutil = "^2.8.2"
-csv-detective = "^0.4.7"
+csv-detective = "^0.6.2"
 
 [tool.poetry.group.dev.dependencies]
 flake8-quotes = "^3.3.1"
@@ -50,6 +50,10 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "catalog_harvested: use catalog_harvested.csv as source",
+]
 
 [tool.poetry.scripts]
 udata-hydra = "udata_hydra.cli:run"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,12 +38,6 @@ def dummy(return_value=None):
     return fn
 
 
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "catalog_harvested: use catalog_harvested.csv as source"
-    )
-
-
 @pytest.fixture
 def is_harvested(request):
     return "catalog_harvested" in [m.name for m in request.node.iter_markers()]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import os
 
 from datetime import datetime
@@ -168,6 +169,7 @@ async def fake_check():
         checksum=None,
         resource_id="c4e3a9fb-4415-488e-ba57-d05269b27adf",
         detected_last_modified_at=None,
+        parsing_table=False,
     ):
         url = f"https://example.com/resource-{resource}"
         data = {
@@ -181,6 +183,7 @@ async def fake_check():
             "error": error,
             "checksum": checksum,
             "detected_last_modified_at": detected_last_modified_at,
+            "parsing_table": hashlib.md5(url.encode("utf-8")).hexdigest() if parsing_table else None,
         }
         id = await insert_check(data)
         data["id"] = id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,10 @@
 NB: we can't use pytest-aiohttp helpers beause
 it will interfere with the rest of our async code
 """
+import hashlib
+
 from datetime import datetime
+
 import pytest
 
 pytestmark = pytest.mark.asyncio
@@ -16,12 +19,13 @@ pytestmark = pytest.mark.asyncio
     ],
 )
 async def test_api_latest(setup_catalog, query, client, fake_check):
-    await fake_check()
+    await fake_check(parsing_table=True)
     resp = await client.get(f"/api/checks/latest/?{query}")
     assert resp.status == 200
     data = await resp.json()
     assert data.pop("created_at")
     assert data.pop("id")
+    url = "https://example.com/resource-1"
     assert data == {
         "response_time": 0.1,
         "deleted": False,
@@ -29,11 +33,15 @@ async def test_api_latest(setup_catalog, query, client, fake_check):
         "catalog_id": 1,
         "domain": "example.com",
         "error": None,
-        "url": "https://example.com/resource-1",
+        "url": url,
         "headers": {"x-do": "you"},
         "timeout": False,
         "dataset_id": "601ddcfc85a59c3a45c2435a",
         "status": 200,
+        "parsing_error": None,
+        "parsing_finished_at": None,
+        "parsing_started_at": None,
+        "parsing_table": hashlib.md5(url.encode("utf-8")).hexdigest(),
     }
 
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -527,8 +527,6 @@ async def test_crawl_triggers_csv_analysis(rmock, event_loop, db, produce_mock, 
     assert len(rmock.requests[("GET", URL(rurl))]) == 1
     res = await db.fetch("SELECT * FROM checks")
     assert len(res) == 1
-    res = await db.fetch("SELECT * FROM csv_analysis")
-    assert len(res) == 1
     assert res[0]["parsing_table"] is not None
     res = await db.fetch(f'SELECT * FROM "{res[0]["parsing_table"]}"')
     assert len(res) == 2

--- a/tests/test_csv_analysis.py
+++ b/tests/test_csv_analysis.py
@@ -195,6 +195,7 @@ async def test_error_reporting_csv_detective(rmock, catalog_content, db, setup_c
     res = await db.fetchrow("SELECT * FROM checks")
     assert res["parsing_table"] is None
     assert res["parsing_error"] == "csv_detective:list index out of range"
+    assert res["parsing_finished_at"]
 
 
 async def test_error_reporting_parsing(rmock, catalog_content, db, setup_catalog, fake_check, produce_mock):
@@ -206,6 +207,7 @@ async def test_error_reporting_parsing(rmock, catalog_content, db, setup_catalog
     res = await db.fetchrow("SELECT * FROM checks")
     assert res["parsing_table"] is None
     assert res["parsing_error"] == "copy_records_to_table:list index out of range"
+    assert res["parsing_finished_at"]
     with pytest.raises(UndefinedTableError):
         await db.execute(f'SELECT * FROM "{table_name}"')
 
@@ -240,5 +242,5 @@ async def test_analyse_csv_send_udata_webhook_error(setup_catalog, rmock, catalo
     webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
     assert webhook.get("analysis:parsing:table") is None
     assert webhook.get("analysis:parsing:started_at")
-    assert webhook.get("analysis:parsing:finished_at") is None
+    assert webhook.get("analysis:parsing:finished_at")
     assert webhook["analysis:parsing:error"] == "copy_records_to_table:list index out of range"

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -257,7 +257,7 @@ async def handle_parse_exception(e: Exception, check_id: int, table_name: str) -
         # e.__cause__ let us access the "inherited" error of ParseException (raise e from cause)
         # it's called explicit exception chaining and it's very cool, look it up (PEP 3134)!
         err = f"{e.step}:sentry:{event_id}" if config.SENTRY_DSN else f"{e.step}:{str(e.__cause__)}"
-        await update_check(check_id, {"parsing_error": err})
+        await update_check(check_id, {"parsing_error": err, "parsing_finished_at": datetime.utcnow()})
         log.error("Parsing error", exc_info=e)
     else:
         raise e

--- a/udata_hydra/app.py
+++ b/udata_hydra/app.py
@@ -34,6 +34,10 @@ class CheckSchema(Schema):
     dataset_id = fields.Str()
     resource_id = fields.UUID()
     deleted = fields.Boolean()
+    parsing_started_at = fields.DateTime()
+    parsing_finished_at = fields.DateTime()
+    parsing_error = fields.Str()
+    parsing_table = fields.Str()
 
 
 class ResourceDocument(Schema):
@@ -62,12 +66,11 @@ class ResourceQuery(Schema):
     document = fields.Nested(ResourceDocument(), allow_none=True)
 
 
-def _get_args(request):
-    url = request.query.get("url")
-    resource_id = request.query.get("resource_id")
-    if not url and not resource_id:
+def _get_args(request, params=("url", "resource_id")):
+    data = [request.query.get(param) for param in params]
+    if not any(data):
         raise web.HTTPBadRequest()
-    return url, resource_id
+    return data
 
 
 @routes.post("/api/resource/created/")

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -234,7 +234,7 @@ async def purge_checks(limit=2):
 async def purge_csv_tables():
     """Delete converted CSV tables for resources no longer in catalog"""
     q = """
-        SELECT parsing_table FROM csv_analysis
+        SELECT parsing_table FROM checks
         WHERE parsing_table IN (
             SELECT md5(url) FROM catalog WHERE deleted = TRUE
         )
@@ -250,7 +250,7 @@ async def purge_csv_tables():
             log.debug(f"Deleting table {table}")
             await delete_table(table)
             await context["conn"].execute(
-                "UPDATE csv_analysis SET parsing_table = NULL WHERE parsing_table = $1", table
+                "UPDATE checks SET parsing_table = NULL WHERE parsing_table = $1", table
             )
             count += 1
     if count:

--- a/udata_hydra/migrations/main/20231102_drop_csv_analysis.sql
+++ b/udata_hydra/migrations/main/20231102_drop_csv_analysis.sql
@@ -1,0 +1,9 @@
+-- remove csv_analysis table and include interesting columns in checks
+
+DROP TABLE csv_analysis;
+
+ALTER TABLE checks
+    ADD parsing_error VARCHAR,
+    ADD parsing_table VARCHAR,
+    ADD parsing_started_at TIMESTAMPTZ,
+    ADD parsing_finished_at TIMESTAMPTZ;

--- a/udata_hydra/utils/db.py
+++ b/udata_hydra/utils/db.py
@@ -61,10 +61,6 @@ async def update_check(check_id: int, data: dict) -> int:
     return await update_table_record("checks", check_id, data)
 
 
-async def update_csv_analysis(csv_analysis_id: int, data: dict) -> int:
-    return await update_table_record("csv_analysis", csv_analysis_id, data)
-
-
 async def get_check(check_id):
     pool = await context.pool()
     async with pool.acquire() as connection:
@@ -76,18 +72,3 @@ async def get_check(check_id):
         """
         check = await connection.fetchrow(q, check_id)
     return check
-
-
-async def insert_csv_analysis(data: dict) -> int:
-    data = convert_dict_values_to_json(data)
-    q = compute_insert_query(data, "csv_analysis")
-    pool = await context.pool()
-    async with pool.acquire() as connection:
-        res = await connection.fetchrow(q, *data.values())
-    return res["id"]
-
-
-async def get_csv_analysis(analysis_id: int):
-    q = "SELECT * FROM csv_analysis WHERE id = $1"
-    pool = await context.pool()
-    return await pool.fetchrow(q, analysis_id)

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -35,7 +35,7 @@ async def download_resource(url: str, headers: dict) -> BinaryIO:
 
     chunk_size = 1024
     i = 0
-    async with aiohttp.ClientSession(headers={"user-agent": config.USER_AGENT}) as session:
+    async with aiohttp.ClientSession(headers={"user-agent": config.USER_AGENT}, raise_for_status=True) as session:
         async with session.get(url, allow_redirects=True) as response:
             async for chunk in response.content.iter_chunked(chunk_size):
                 if i * chunk_size < float(config.MAX_FILESIZE_ALLOWED):

--- a/udata_hydra/utils/timer.py
+++ b/udata_hydra/utils/timer.py
@@ -1,0 +1,31 @@
+import logging
+import time
+
+log = logging.getLogger("udata-hydra")
+
+
+class Timer:
+    """
+    A simple Timer class for code execution time measurement as a debug log.
+
+    ```
+    timer = Timer("my-timer")
+    timer.mark("a-step")
+    timer.stop()
+    ```
+    """
+    steps = []
+
+    def __init__(self, name) -> None:
+        self.name = name
+        self.steps.append(time.perf_counter())
+
+    def mark(self, step: str) -> None:
+        t_mark = time.perf_counter()
+        t_delta = t_mark - self.steps[-1]
+        self.steps.append(t_mark)
+        log.debug(f"[{self.name}] {step} done in {t_delta:0.4f}s")
+
+    def stop(self) -> None:
+        t_delta = time.perf_counter() - self.steps[0]
+        log.debug(f"[{self.name}] Total time {t_delta:0.4f}s")


### PR DESCRIPTION
So I tried to add an API endpoint for analysis results and I realised the `csv_analysis` table was more of a hassle than anything — just like we discussed.

Thus `csv_analysis` is removed, interesting columns are integrated to `checks` and the `checks` API now handles csv analysis results.