### PR TITLE
Use profiling option from csv-detective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Use profiling option from csv-detective [#54](https://github.com/etalab/udata-hydra/pull/54)
 - Add new types for csv parsing: json, date and datetime [#51](https://github.com/etalab/udata-hydra/pull/51)
 - Notify udata of csv parsing [#51](https://github.com/etalab/udata-hydra/pull/51)
 - Allow `None` values in udata notifications [#51](https://github.com/etalab/udata-hydra/pull/51)

--- a/poetry.lock
+++ b/poetry.lock
@@ -397,18 +397,6 @@ files = [
 ]
 
 [[package]]
-name = "chardet"
-version = "5.1.0"
-description = "Universal encoding detector for Python 3"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "chardet-5.1.0-py3-none-any.whl", hash = "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"},
-    {file = "chardet-5.1.0.tar.gz", hash = "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5"},
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -470,24 +458,20 @@ cron = ["capturer (>=2.4)"]
 
 [[package]]
 name = "csv-detective"
-version = "0.4.7"
+version = "0.6.2"
 description = "Detect CSV column content"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "csv_detective-0.4.7.tar.gz", hash = "sha256:8bbe44bfd2241c9cb01e25174297f71b0a0df1d9e99d9023c561338fb7ab315c"},
+    {file = "csv_detective-0.6.2-py3-none-any.whl", hash = "sha256:98c2ec702ee7c8a04d90ed64e4589e1e02ca00b2efae2e1be5e445deeff41ff7"},
 ]
 
 [package.dependencies]
 boto3 = ">=1.21.21"
 cchardet = "*"
-chardet = ">=3.0"
 pandas = ">=0.20"
 unidecode = ">=0.4"
-
-[package.extras]
-test = ["nose"]
 
 [[package]]
 name = "dateparser"
@@ -1781,4 +1765,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e21d5cc18bbdecaab120785931da7806d179045ca18146a595885a5ebdc342b4"
+content-hash = "634c188b837ad53f0de11c1d009775360b887c58c216d8a66739bd7233ff2237"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ str2bool = "^1.1"
 sqlalchemy = "^1.4.46"
 dateparser = "^1.1.7"
 python-dateutil = "^2.8.2"
-csv-detective = "^0.4.7"
+csv-detective = "^0.6.2"
 
 [tool.poetry.group.dev.dependencies]
 flake8-quotes = "^3.3.1"
@@ -50,6 +50,9 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.poetry.scripts]
 udata-hydra = "udata_hydra.cli:run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ build-backend = "poetry.core.masonry.api"
 asyncio_mode = "strict"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "catalog_harvested: use catalog_harvested.csv as source",
 ]
 
 [tool.poetry.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,12 +38,6 @@ def dummy(return_value=None):
     return fn
 
 
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "catalog_harvested: use catalog_harvested.csv as source"
-    )
-
-
 @pytest.fixture
 def is_harvested(request):
     return "catalog_harvested" in [m.name for m in request.node.iter_markers()]

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -35,7 +35,7 @@ async def download_resource(url: str, headers: dict) -> BinaryIO:
 
     chunk_size = 1024
     i = 0
-    async with aiohttp.ClientSession(headers={"user-agent": config.USER_AGENT}) as session:
+    async with aiohttp.ClientSession(headers={"user-agent": config.USER_AGENT}, raise_for_status=True) as session:
         async with session.get(url, allow_redirects=True) as response:
             async for chunk in response.content.iter_chunked(chunk_size):
                 if i * chunk_size < float(config.MAX_FILESIZE_ALLOWED):

--- a/udata_hydra/utils/timer.py
+++ b/udata_hydra/utils/timer.py
@@ -1,0 +1,31 @@
+import logging
+import time
+
+log = logging.getLogger("udata-hydra")
+
+
+class Timer:
+    """
+    A simple Timer class for code execution time measurement as a debug log.
+
+    ```
+    timer = Timer("my-timer")
+    timer.mark("a-step")
+    timer.stop()
+    ```
+    """
+    steps = []
+
+    def __init__(self, name) -> None:
+        self.name = name
+        self.steps.append(time.perf_counter())
+
+    def mark(self, step: str) -> None:
+        t_mark = time.perf_counter()
+        t_delta = t_mark - self.steps[-1]
+        self.steps.append(t_mark)
+        log.debug(f"[{self.name}] {step} done in {t_delta:0.4f}s")
+
+    def stop(self) -> None:
+        t_delta = time.perf_counter() - self.steps[0]
+        log.debug(f"[{self.name}] Total time {t_delta:0.4f}s")


### PR DESCRIPTION
This uses the `output_profile` from `csv-detective`, for which we need to analyse the whole file and not a sample.

This makes things significantly slower (cf below). I added a `Timer` class because that's something I've been doing a lot :-)

## with profile, num_rows=-1

```
$ poetry run udata-hydra analyse-csv --url https://static.data.gouv.fr/resources/annuaire-des-diagnostiqueurs-immobiliers/20230211-210014/annuaire-diagnostiqueurs.csv
2023-02-13 09:51:45 dev.local asyncio[48697] DEBUG Using selector: KqueueSelector
2023-02-13 09:51:46 dev.local udata-hydra[48697] DEBUG [analyse-csv] download-file done in 0.9991s
2023-02-13 09:52:13 dev.local udata-hydra[48697] DEBUG [analyse-csv] csv-inspection done in 26.5583s
2023-02-13 09:52:13 dev.local udata-hydra[48697] DEBUG Converting from CSV to db for f21ac1d59231f25f783e3c1473cf998a
2023-02-13 09:52:25 dev.local udata-hydra[48697] DEBUG [analyse-csv] csv-to-db done in 12.0488s
2023-02-13 09:52:25 dev.local udata-hydra[48697] DEBUG [analyse-csv] Total time 39.6194s
```

```
$ poetry run udata-hydra analyse-csv --url http://data.caf.fr/dataset/f6411f07-10bf-4f13-b4fb-8d30ba9328b5/resource/94a182c4-19c8-4d3a-987c-187a49756365/download/txcouvglo2014.csv
2023-02-13 09:48:27 dev.local asyncio[48302] DEBUG Using selector: KqueueSelector
2023-02-13 09:48:28 dev.local udata-hydra[48302] DEBUG [analyse-csv] download-file done in 0.9730s
2023-02-13 09:48:40 dev.local udata-hydra[48302] DEBUG [analyse-csv] csv-inspection done in 11.8303s
2023-02-13 09:48:40 dev.local udata-hydra[48302] DEBUG Converting from CSV to db for 3e1b3d2ce6e2f7f16c3f7d2183a08eef
2023-02-13 09:48:41 dev.local udata-hydra[48302] DEBUG [analyse-csv] csv-to-db done in 0.7035s
2023-02-13 09:48:41 dev.local udata-hydra[48302] DEBUG [analyse-csv] Total time 13.5182s
```

## default routine

```
$ poetry run udata-hydra analyse-csv --url https://static.data.gouv.fr/resources/annuaire-des-diagnostiqueurs-immobiliers/20230211-210014/annuaire-diagnostiqueurs.csv
2023-02-13 09:54:29 dev.local asyncio[48911] DEBUG Using selector: KqueueSelector
2023-02-13 09:54:29 dev.local udata-hydra[48911] DEBUG [analyse-csv] download-file done in 0.3583s
2023-02-13 09:54:36 dev.local udata-hydra[48911] DEBUG [analyse-csv] csv-inspection done in 6.1585s
2023-02-13 09:54:36 dev.local udata-hydra[48911] DEBUG Converting from CSV to db for f21ac1d59231f25f783e3c1473cf998a
2023-02-13 09:54:47 dev.local udata-hydra[48911] DEBUG [analyse-csv] csv-to-db done in 11.1716s
2023-02-13 09:54:47 dev.local udata-hydra[48911] DEBUG [analyse-csv] Total time 17.7011s
```

```
$ poetry run udata-hydra analyse-csv --url http://data.caf.fr/dataset/f6411f07-10bf-4f13-b4fb-8d30ba9328b5/resource/94a182c4-19c8-4d3a-987c-187a49756365/download/txcouvglo2014.csv
2023-02-13 09:55:10 dev.local asyncio[48993] DEBUG Using selector: KqueueSelector
2023-02-13 09:55:11 dev.local udata-hydra[48993] DEBUG [analyse-csv] download-file done in 0.9826s
2023-02-13 09:55:15 dev.local udata-hydra[48993] DEBUG [analyse-csv] csv-inspection done in 4.0702s
2023-02-13 09:55:15 dev.local udata-hydra[48993] DEBUG Converting from CSV to db for 3e1b3d2ce6e2f7f16c3f7d2183a08eef
2023-02-13 09:55:16 dev.local udata-hydra[48993] DEBUG [analyse-csv] csv-to-db done in 0.7111s
2023-02-13 09:55:16 dev.local udata-hydra[48993] DEBUG [analyse-csv] Total time 5.7751s
```