### PR TITLE
allow to configure a dedicated PostgreSQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow `None` values in udata notifications [#51](https://github.com/etalab/udata-hydra/pull/51)
 - Add tests for udata-triggered checks [#49](https://github.com/etalab/udata-hydra/pull/49)
 - Include migration files in package
+- Allow to configure a dedicated PostgreSQL schema [#56](https://github.com/etalab/udata-hydra/pull/56)
 
 ## 1.0.1 (2023-01-04)
 

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -3,6 +3,7 @@ LOG_LEVEL = "DEBUG"
 DATABASE_URL = "postgres://postgres:postgres@localhost:5432/postgres"
 # csv as database table
 DATABASE_URL_CSV = "postgres://postgres:postgres@localhost:5434/postgres"
+DATABASE_SCHEMA = "public"
 REDIS_URL = "redis://localhost:6379/0"
 SENTRY_DSN = ""
 TESTING = false

--- a/udata_hydra/context.py
+++ b/udata_hydra/context.py
@@ -35,7 +35,7 @@ async def pool(db="main"):
             dsn=dsn,
             max_size=config.MAX_POOL_SIZE,
             server_settings={
-                "search_path": getattr(config, "DATABASE_SCHEMA")
+                "search_path": config.DATABASE_SCHEMA
             }
         )
     return context["databases"][db]

--- a/udata_hydra/context.py
+++ b/udata_hydra/context.py
@@ -31,7 +31,13 @@ def monitor():
 async def pool(db="main"):
     if db not in context["databases"]:
         dsn = config.DATABASE_URL if db == "main" else getattr(config, f"DATABASE_URL_{db.upper()}")
-        context["databases"][db] = await asyncpg.create_pool(dsn=dsn, max_size=config.MAX_POOL_SIZE)
+        context["databases"][db] = await asyncpg.create_pool(
+            dsn=dsn,
+            max_size=config.MAX_POOL_SIZE,
+            server_settings={
+                "search_path": getattr(config, "DATABASE_SCHEMA")
+            }
+        )
     return context["databases"][db]
 
 


### PR DESCRIPTION
Use `asyncpg` to configure a dedicated PostgreSQL schema: https://magicstack.github.io/asyncpg/current/api/index.html

By default it's configured to use the pre-defined `public` schema.