### PR TITLE
Update dates following udata refacto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Allow to configure a dedicated PostgreSQL schema [#56](https://github.com/etalab/udata-hydra/pull/56)
 - Fix typo in handle_parse_exception and schema in CLI [#57](https://github.com/etalab/udata-hydra/pull/57)
 - Skip archived dataset when loading catalog [#58](https://github.com/etalab/udata-hydra/pull/58)
+- Update resources expected dates in API following udata refactoring [#60](https://github.com/etalab/udata-hydra/pull/60)
 
 ## 1.0.1 (2023-01-04)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,6 @@ def udata_resource_payload():
             "checksum_type": "sha1",
             "checksum_value": "b7b1cd8230881b18b6b487d550039949867ec7c5",
             "created_at": datetime.now().isoformat(),
-            "modified": datetime.now().isoformat(),
-            "published": datetime.now().isoformat(),
+            "last_modified": datetime.now().isoformat(),
         }
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -149,8 +149,7 @@ async def test_api_resource_updated(client):
             "checksum_type": "sha1",
             "checksum_value": "b7b1cd8230881b18b6b487d550039949867ec7c5",
             "created_at": datetime.now().isoformat(),
-            "modified": datetime.now().isoformat(),
-            "published": datetime.now().isoformat(),
+            "last_modified": datetime.now().isoformat(),
         }
     }
     resp = await client.post("/api/resource/updated/", json=payload)

--- a/udata_hydra/app.py
+++ b/udata_hydra/app.py
@@ -54,8 +54,7 @@ class ResourceDocument(Schema):
     checksum_type = fields.Str(allow_none=True)
     checksum_value = fields.Str(allow_none=True)
     created_at = fields.DateTime(required=True)
-    modified = fields.DateTime(required=True)
-    published = fields.DateTime(required=True)
+    last_modified = fields.DateTime(required=True)
     extras = fields.Dict()
     harvest = fields.Dict()
 


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/2815

`published` date has been removed and `modified` renamed to `last_modified`