### PR TITLE
Send content-type and content-length header to udata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Skip archived dataset when loading catalog [#58](https://github.com/etalab/udata-hydra/pull/58)
 - Update resources expected dates in API following udata refactoring [#60](https://github.com/etalab/udata-hydra/pull/60)
 - Download csv resource only if first check [#61](https://github.com/etalab/udata-hydra/pull/61)
+- Send content-type and content-length info from header to udata [#64](https://github.com/etalab/udata-hydra/pull/64)
 
 ## 1.0.1 (2023-01-04)
 


### PR DESCRIPTION
In `check_url`, send useful headers info to udata.
We're currently sending `content-type` and `content-length`, useful for preview.