### PR TITLE
Rename analysis filesize to content-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Download csv resource only if first check [#61](https://github.com/etalab/udata-hydra/pull/61)
 - Send content-type and content-length info from header to udata [#64](https://github.com/etalab/udata-hydra/pull/64)
 - Add timezone values to dates sent to udata [#63](https://github.com/etalab/udata-hydra/pull/63)
+- Rename analysis filesize to content-length [#66](https://github.com/etalab/udata-hydra/pull/66)
 
 ## 1.0.1 (2023-01-04)
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ The payload should look something like:
 
 ```json
 {
-   "analysis:filesize": 91661,
+   "analysis:content-length": 91661,
    "analysis:mime-type": "application/zip",
    "analysis:checksum": "bef1de04601dedaf2d127418759b16915ba083be",
    "analysis:last-modified-at": "2022-11-27T23:00:54.762000",

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -365,7 +365,7 @@ async def test_process_resource_send_udata(setup_catalog, mocker, rmock, fake_ch
     req = rmock.requests[("PUT", URL(udata_url))]
     assert len(req) == 1
     document = req[0].kwargs["json"]
-    assert document["analysis:filesize"] == len(SIMPLE_CSV_CONTENT)
+    assert document["analysis:content-length"] == len(SIMPLE_CSV_CONTENT)
     assert document["analysis:mime-type"] == "text/plain"
 
 

--- a/udata_hydra/analysis/resource.py
+++ b/udata_hydra/analysis/resource.py
@@ -63,7 +63,7 @@ async def process_resource(check_id: int, is_first_check: bool) -> None:
             dl_analysis["analysis:error"] = "File too large to download"
         else:
             # Get file size
-            dl_analysis["analysis:filesize"] = os.path.getsize(tmp_file.name)
+            dl_analysis["analysis:content-length"] = os.path.getsize(tmp_file.name)
             # Get checksum
             dl_analysis["analysis:checksum"] = compute_checksum_from_file(tmp_file.name)
             # Check if checksum has been modified if we don't have other hints
@@ -78,7 +78,7 @@ async def process_resource(check_id: int, is_first_check: bool) -> None:
             await update_check(check_id, {
                 "checksum": dl_analysis.get("analysis:checksum"),
                 "analysis_error": dl_analysis.get("analysis:error"),
-                "filesize": dl_analysis.get("analysis:filesize"),
+                "filesize": dl_analysis.get("analysis:content-length"),
                 "mime_type": dl_analysis.get("analysis:mime-type"),
             })
 


### PR DESCRIPTION
More coherent with check:headers:content-length