### PR TITLE
Sleep between all batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Send content-type and content-length info from header to udata [#64](https://github.com/etalab/udata-hydra/pull/64)
 - Add timezone values to dates sent to udata [#63](https://github.com/etalab/udata-hydra/pull/63)
 - Rename analysis filesize to content-length [#66](https://github.com/etalab/udata-hydra/pull/66)
+- Sleep between all batches [#67](https://github.com/etalab/udata-hydra/pull/67)
 
 ## 1.0.1 (2023-01-04)
 

--- a/udata_hydra/crawl.py
+++ b/udata_hydra/crawl.py
@@ -367,7 +367,7 @@ async def crawl_batch():
         await crawl_urls(to_check)
     else:
         context.monitor().set_status("Nothing to crawl for now.")
-        await asyncio.sleep(config.SLEEP_BETWEEN_BATCHES)
+    await asyncio.sleep(config.SLEEP_BETWEEN_BATCHES)
 
 
 async def crawl(iterations=-1):


### PR DESCRIPTION
Sleep for `SLEEP_BETWEEN_BATCHES` whether there are urls to crawl or not.

When most urls left to crawl are urls on which we backoff, we end up in a loop where we always have some urls `to_check` but can't and never sleep.
Seems like sleeping between all batches allow for a slower pace to crawl all urls as well, aside from the backoff reason.