### PR TITLE
Add health route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Rename analysis filesize to content-length [#66](https://github.com/etalab/udata-hydra/pull/66)
 - Sleep between all batches [#67](https://github.com/etalab/udata-hydra/pull/67)
 - Support having multiple crawlers by setting a status column in the catalog table [#68](https://github.com/etalab/udata-hydra/pull/68)
+- Add a health route [#69](https://github.com/etalab/udata-hydra/pull/69)
 
 ## 1.0.1 (2023-01-04)
 

--- a/udata_hydra/app.py
+++ b/udata_hydra/app.py
@@ -317,6 +317,13 @@ async def stats(request):
     )
 
 
+@routes.get("/api/health/")
+async def health(request):
+    test_connection = await request.app["pool"].fetchrow("SELECT 1")
+    assert next(test_connection.values()) == 1
+    return web.HTTPOk()
+
+
 async def app_factory():
     async def app_startup(app):
         app["pool"] = await context.pool()


### PR DESCRIPTION
Add health route, that assert Postgres connection and returns a 200.

The Postgres connection tests runs a `SELECT 1`, similar to what has been done in PostgREST [in their ready route](https://github.com/PostgREST/postgrest/blob/e572d1d1a2ea14cd4505be2fa0c2c08e46d32997/src/PostgREST/Workers.hs#L295).