### PR TITLE
Improve on the backoff logic

### DIFF
--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -229,7 +229,69 @@ async def test_backoff_rate_limiting(setup_catalog, event_loop, rmock, fake_chec
         assert ("HEAD", URL(rurl)) in rmock.requests
 
 
-async def test_backoff_lifted(setup_catalog, event_loop, rmock, mocker, fake_check, produce_mock, db):
+async def test_backoff_rate_limiting_lifted(setup_catalog, event_loop, rmock, mocker, fake_check, produce_mock, db):
+    await fake_check(
+        resource=2,
+        resource_id="c5187912-24a5-49ea-a725-5e1e3d472efe",
+        headers={
+            "x-ratelimit-remaining": 1,  # our 10% quota has been reached
+            "x-ratelimit-limit": 10,
+        }
+    )
+    mocker.patch("udata_hydra.config.BACKOFF_PERIOD", 0.25)
+    rurl = "https://example.com/resource-1"
+    rmock.head(rurl, status=200)
+    rmock.get(rurl, status=200)
+    # We should backoff
+    row = await db.fetchrow("SELECT * FROM catalog")
+    async with ClientSession() as session:
+        res = await check_url(row, session)
+    assert res == STATUS_BACKOFF
+    assert ("HEAD", URL(rurl)) not in rmock.requests
+
+    # we wait for BACKOFF_PERIOD before crawling again, it should _not_ backoff
+    async with ClientSession() as session:
+        res = await check_url(row, session, sleep=0.25)
+    assert res != STATUS_BACKOFF
+    assert ("HEAD", URL(rurl)) in rmock.requests
+
+
+async def test_backoff_rate_limiting_cooled_off(setup_catalog, event_loop, rmock, mocker, fake_check, produce_mock, db):
+    await fake_check(
+        resource=2,
+        resource_id="c5187912-24a5-49ea-a725-5e1e3d472efe",
+        headers={
+            "x-ratelimit-remaining": 0,  # we've messed up
+            "x-ratelimit-limit": 10,
+        }
+    )
+    mocker.patch("udata_hydra.config.BACKOFF_PERIOD", 0.25)
+    mocker.patch("udata_hydra.config.COOL_OFF_PERIOD", 0.5)
+    rurl = "https://example.com/resource-1"
+    rmock.head(rurl, status=200)
+    rmock.get(rurl, status=200)
+    # We should backoff
+    row = await db.fetchrow("SELECT * FROM catalog")
+    async with ClientSession() as session:
+        res = await check_url(row, session)
+    assert res == STATUS_BACKOFF
+    assert ("HEAD", URL(rurl)) not in rmock.requests
+
+    # waiting for BACKOFF_PERIOD is not enough since we've messed up already
+    async with ClientSession() as session:
+        res = await check_url(row, session, sleep=0.25)
+    assert res == STATUS_BACKOFF
+    assert ("HEAD", URL(rurl)) not in rmock.requests
+
+    # we wait until COOL_OFF_PERIOD (0.25+0.25) before crawling again,
+    # it should _not_ backoff
+    async with ClientSession() as session:
+        res = await check_url(row, session, sleep=0.25)
+    assert res != STATUS_BACKOFF
+    assert ("HEAD", URL(rurl)) in rmock.requests
+
+
+async def test_backoff_nb_req_lifted(setup_catalog, event_loop, rmock, mocker, fake_check, produce_mock, db):
     await fake_check(resource=2, resource_id="c5187912-24a5-49ea-a725-5e1e3d472efe")
     mocker.patch("udata_hydra.config.BACKOFF_NB_REQ", 1)
     mocker.patch("udata_hydra.config.BACKOFF_PERIOD", 0.25)
@@ -252,16 +314,26 @@ async def test_backoff_on_429_status_code(setup_catalog, event_loop, rmock, mock
     resource_id = "c5187912-24a5-49ea-a725-5e1e3d472efe"
     await fake_check(resource=2, resource_id=resource_id)
     mocker.patch("udata_hydra.config.BACKOFF_PERIOD", 0.25)
+    mocker.patch("udata_hydra.config.COOL_OFF_PERIOD", 0.5)
     rurl = "https://example.com/resource-1"
     await db.execute("UPDATE checks SET status = 429 WHERE resource_id = $1", resource_id)
     rmock.head(rurl, status=200)
     row = await db.fetchrow("SELECT * FROM catalog")
+
+    # we've messed up, we should backoff
     async with ClientSession() as session:
         res = await check_url(row, session)
     assert res == STATUS_BACKOFF
-    # verify that we actually backed-off
     assert ("HEAD", URL(rurl)) not in rmock.requests
-    # we wait for BACKOFF_PERIOD before crawling again, it should _not_ backoff
+
+    # waiting for BACKOFF_PERIOD is not enough since we've messed up already
+    async with ClientSession() as session:
+        res = await check_url(row, session, sleep=0.25)
+    assert res == STATUS_BACKOFF
+    assert ("HEAD", URL(rurl)) not in rmock.requests
+
+    # we wait until COOL_OFF_PERIOD (0.25+0.25) before crawling again,
+    # it should _not_ backoff
     async with ClientSession() as session:
         res = await check_url(row, session, sleep=0.25)
     assert res != STATUS_BACKOFF

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -30,6 +30,8 @@ NO_BACKOFF_DOMAINS = [
 # max number of _completed_ requests per domain per period
 BACKOFF_NB_REQ = 180
 BACKOFF_PERIOD = 360  # in seconds
+COOL_OFF_PERIOD = 86400 # 1 day to cool off when we've messed up
+
 # crawl batch size, beware of open file limits
 # ⚠️ do not exceed MAX_POOL_SIZE
 BATCH_SIZE = 40

--- a/udata_hydra/crawl.py
+++ b/udata_hydra/crawl.py
@@ -128,7 +128,7 @@ async def is_backoff(domain) -> Tuple[bool, str]:
     backoff = False, ""
     no_backoff = [f"'{d}'" for d in config.NO_BACKOFF_DOMAINS]
     no_backoff = f"({','.join(no_backoff)})"
-    since = datetime.now(timezone.utc) - timedelta(seconds=config.BACKOFF_PERIOD)
+    since_backoff_period = datetime.now(timezone.utc) - timedelta(seconds=config.BACKOFF_PERIOD)
     pool = await context.pool()
     async with pool.acquire() as connection:
         # check if we trigger BACKOFF_NB_REQ for BACKOFF_PERIOD on this domain
@@ -140,12 +140,13 @@ async def is_backoff(domain) -> Tuple[bool, str]:
             AND domain NOT IN {no_backoff}
         """,
             domain,
-            since,
+            since_backoff_period,
         )
         backoff = res["count"] >= config.BACKOFF_NB_REQ, f"Too many requests: {res['count']}"
 
         if not backoff[0]:
-            # check if we hit a ratelimit on this domain
+            # check if we hit a ratelimit or received a 429 on this domain since COOL_OFF_PERIOD
+            since_cool_off_period = datetime.now(timezone.utc) - timedelta(seconds=config.COOL_OFF_PERIOD)
             q = f"""
                 SELECT
                     headers->>'x-ratelimit-remaining' as ratelimit_remaining,
@@ -154,13 +155,15 @@ async def is_backoff(domain) -> Tuple[bool, str]:
                     created_at
                 FROM checks
                 WHERE domain = $1 AND domain NOT IN {no_backoff}
+                AND created_at >= $2
                 ORDER BY created_at DESC
                 LIMIT 1
             """
-            res = await connection.fetchrow(q, domain)
+            res = await connection.fetchrow(q, domain, since_cool_off_period)
             if res:
-                if res["status"] == 429 and res["created_at"] > since:
-                    # we have made too many requests already and haven't cooled off yet
+                if res["status"] == 429:
+                    # we have made too many requests already haven't cooled off yet
+                    # TODO: we could also user Retry-after, but it isn't returned correctly on 429 we're getting
                     return True, "429 status code has been returned on the latest call"
                 try:
                     remain, limit = float(res["ratelimit_remaining"]), float(res["ratelimit_limit"])
@@ -169,9 +172,12 @@ async def is_backoff(domain) -> Tuple[bool, str]:
                 else:
                     if limit == -1:
                         return False, ""
-                    very_limited = remain == 0 or limit == 0
-                    # we have really messed up or less than 10% left from our quota, we backoff
-                    backoff = very_limited or remain / limit <= 0.1, "X-ratelimit reached"
+                    if remain == 0 or limit == 0:
+                        # we have really messed up
+                        backoff = True, "X-ratelimit reached"
+                    elif remain / limit <= 0.1 and res["created_at"] > since_backoff_period:
+                        # less than 10% left from our quota, we're backing off until backoff period
+                        backoff = True, "X-ratelimit reached"
 
     return backoff
 

--- a/udata_hydra/crawl.py
+++ b/udata_hydra/crawl.py
@@ -162,7 +162,7 @@ async def is_backoff(domain) -> Tuple[bool, str]:
             res = await connection.fetchrow(q, domain, since_cool_off_period)
             if res:
                 if res["status"] == 429:
-                    # we have made too many requests already haven't cooled off yet
+                    # we have made too many requests already and haven't cooled off yet
                     # TODO: we could also user Retry-after, but it isn't returned correctly on 429 we're getting
                     return True, "429 status code has been returned on the latest call"
                 try:


### PR DESCRIPTION
We were currently waiting forever on ratelimit backoff, since we used last check without any limit of time.
We're now looking at a last check since a COOL_OFF_PERIOD.
In particular, we're waiting for a COOL_OFF_PERIOD if we've messed up or a simple BACKOFF_PERIOD if we've reached our ratelimit quota.

At the contrary, when receiving a 429, we only waited for a BACKOFF_PERIOD, which is not enough when we've messed up. Now we're waiting for a COOL_OFF_PERIOD.

Not sure if the backoff logic could be more readable, interested in suggestions.

___
Default values:
COOL_OFF_PERIOD  = 1day
BACKOFF_PERIOD  = 6 min