### PR TITLE
Fix conflict on updating catalog with multiple entries for a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Support having multiple crawlers by setting a status column in the catalog table [#68](https://github.com/etalab/udata-hydra/pull/68)
 - Add a health route [#69](https://github.com/etalab/udata-hydra/pull/69)
 - Make temporary folder configurable [#70](https://github.com/etalab/udata-hydra/pull/70)
+- Fix conflict on updating catalog with multiple entries for a resource [#73](https://github.com/etalab/udata-hydra/pull/73)
 
 ## 1.0.1 (2023-01-04)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -168,7 +168,8 @@ async def test_api_resource_updated_bug(setup_catalog, db, client):
 
     # We add a another entry of (dataset_id,resource_id) into the catalog with a different url
     await db.execute("INSERT INTO catalog (dataset_id, resource_id, url, deleted, priority) "
-                     "VALUES('601ddcfc85a59c3a45c2435a', 'c4e3a9fb-4415-488e-ba57-d05269b27adf', 'https://example.com/resource-0', TRUE, FALSE)")
+                     "VALUES('601ddcfc85a59c3a45c2435a', 'c4e3a9fb-4415-488e-ba57-d05269b27adf', "
+                     "'https://example.com/resource-0', TRUE, FALSE)")
     # We have two entries for this (dataset_id,resource_id) tuple
     res = await db.fetch("SELECT * FROM catalog WHERE dataset_id = $1 AND resource_id = $2",
                          "601ddcfc85a59c3a45c2435a", "c4e3a9fb-4415-488e-ba57-d05269b27adf")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -188,8 +188,8 @@ async def test_api_resource_updated_url_since_load_catalog(setup_catalog, db, cl
             "last_modified": datetime.now().isoformat(),
         }
     }
-    # It does not create any duplicated resource
-    # entries get updated and set the same url, leading to a conflict
+    # It does not create any duplicated resource.
+    # The existing entry get updated accordingly.
     resp = await client.post("/api/resource/updated/", json=payload)
     assert resp.status == 200
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -164,6 +164,44 @@ async def test_api_resource_updated(client):
     assert text == "Missing document body"
 
 
+async def test_api_resource_updated_bug(setup_catalog, db, client):
+
+    # We add a another entry of (dataset_id,resource_id) into the catalog with a different url
+    await db.execute("INSERT INTO catalog (dataset_id, resource_id, url, deleted, priority) "
+                     "VALUES('601ddcfc85a59c3a45c2435a', 'c4e3a9fb-4415-488e-ba57-d05269b27adf', 'https://example.com/resource-0', TRUE, FALSE)")
+    # We have two entries for this (dataset_id,resource_id) tuple
+    res = await db.fetch("SELECT * FROM catalog WHERE dataset_id = $1 AND resource_id = $2",
+                         "601ddcfc85a59c3a45c2435a", "c4e3a9fb-4415-488e-ba57-d05269b27adf")
+    assert len(res) == 2
+
+    # We're sending an update signal on the (dataset_id,resource_id) with the same url as above
+    # (or a different one, it does not matter).
+    payload = {
+        "resource_id": "c4e3a9fb-4415-488e-ba57-d05269b27adf",
+        "dataset_id": "601ddcfc85a59c3a45c2435a",
+        "document": {
+            "id": "f8fb4c7b-3fc6-4448-b34f-81a9991f18ec",
+            "url": "https://example.com/resource-0",
+            "title": "random title",
+            "description": "random description",
+            "filetype": "file",
+            "type": "documentation",
+            "mime": "text/plain",
+            "filesize": 1024,
+            "checksum_type": "sha1",
+            "checksum_value": "b7b1cd8230881b18b6b487d550039949867ec7c5",
+            "created_at": datetime.now().isoformat(),
+            "last_modified": datetime.now().isoformat(),
+        }
+    }
+    # It fails due to UNIQUE(dataset_id, resource_id, url) constraint. Both
+    # entries get updated and set the same url, leading to a conflict
+    resp = await client.post("/api/resource/updated/", json=payload)
+    assert resp.status == 500
+    data = await resp.text()
+    assert data == "500 Internal Server Error\n\nServer got itself in trouble"
+
+
 async def test_api_resource_deleted(client):
     payload = {
         "resource_id": "f8fb4c7b-3fc6-4448-b34f-81a9991f18ec",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,8 @@ async def test_load_catalog_url_has_changed(setup_catalog, rmock, db, catalog_co
     run("load_catalog", url=catalog)
 
     # check that we now have two entries for this resource in the catalog
-    res = await db.fetch("SELECT * FROM catalog WHERE resource_id = $1 ORDER BY url ASC", "c4e3a9fb-4415-488e-ba57-d05269b27adf")
+    res = await db.fetch("SELECT * FROM catalog WHERE resource_id = $1 ORDER BY url ASC",
+                         "c4e3a9fb-4415-488e-ba57-d05269b27adf")
     assert len(res) == 2
     assert res[0]["url"] == "https://example.com/resource-0"
     assert res[0]["deleted"] is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,31 @@ async def test_purge_csv_tables_url_used_by_other_resource(setup_catalog, db, fa
     assert res is not None
 
 
+async def test_purge_csv_tables_url_used_by_deleted_resource_only(setup_catalog, db, fake_check):
+    """We should delete csv table if all resource with this url are marked as deleted"""
+    # pretend we have a csv_analysis with a converted table for this url
+    check = await fake_check(parsing_table=True)
+    md5 = check["parsing_table"]
+    await db.execute(f'CREATE TABLE "{md5}"(id serial)')
+    # check table is there before purge
+    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
+    assert res is not None
+    # pretend the resource is deleted
+    await db.execute("UPDATE catalog SET deleted = TRUE")
+    # insert another deleted resource with same url
+    await db.execute(
+        "INSERT INTO catalog (dataset_id, resource_id, url, deleted, priority) VALUES($1, $2, $3, $4, $5)",
+        "6115eed4acb337ce13b83db3", "7a0c10a0-8e6f-403f-a987-2e223b22ee33", check["url"], True, False
+    )
+    # purge
+    run("purge_csv_tables")
+    # check table is gone
+    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
+    assert res is None
+    res = await db.fetchrow("SELECT * FROM tables_index WHERE parsing_table = $1", md5)
+    assert res is None
+
+
 async def test_load_catalog_url_has_changed(setup_catalog, rmock, db, catalog_content):
     # the resource url has changed in comparison to load_catalog
     catalog_content = catalog_content.replace(b"https://example.com/resource-1", b"https://example.com/resource-0")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,3 +56,24 @@ async def test_purge_csv_tables_url_used_by_other_resource(setup_catalog, db, fa
     # check table is _not_ gone
     res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
     assert res is not None
+
+
+async def test_load_catalog_url_has_changed(setup_catalog, rmock, db, catalog_content):
+    # Check that we have one entry in the catalog for our resource of interest
+    res = await db.fetch("SELECT * FROM catalog WHERE resource_id = $1", "c4e3a9fb-4415-488e-ba57-d05269b27adf")
+    assert len(res) == 1
+
+    # the resource url has changed in comparison to load_catalog
+    catalog_content = catalog_content.replace(b"https://example.com/resource-1", b"https://example.com/resource-0")
+    catalog = "https://example.com/catalog"
+    rmock.get(catalog, status=200, body=catalog_content)
+    run("load_catalog", url=catalog)
+
+    # check that we now have two entries for this resource in the catalog
+    res = await db.fetch("SELECT * FROM catalog WHERE resource_id = $1 ORDER BY url ASC", "c4e3a9fb-4415-488e-ba57-d05269b27adf")
+    assert len(res) == 2
+    assert res[0]["url"] == "https://example.com/resource-0"
+    assert res[0]["deleted"] is False
+
+    assert res[1]["url"] == "https://example.com/resource-1"
+    assert res[1]["deleted"] is True

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -24,7 +24,6 @@ from udata_hydra.analysis.resource import process_resource
 from udata_hydra.utils.db import get_check
 
 from .conftest import RESOURCE_ID as resource_id
-from .conftest import DATASET_ID as dataset_id
 
 
 # TODO: make file content configurable

--- a/udata_hydra/app.py
+++ b/udata_hydra/app.py
@@ -94,7 +94,10 @@ async def resource_created(request):
         q = f"""
                 INSERT INTO catalog (dataset_id, resource_id, url, deleted, priority)
                 VALUES ('{dataset_id}', '{resource_id}', '{resource["url"]}', FALSE, TRUE)
-                ON CONFLICT (dataset_id, resource_id, url) DO UPDATE SET priority = TRUE;"""
+                ON CONFLICT (resource_id) DO UPDATE SET
+                    priority = TRUE,
+                    url = '{resource["url"]}',
+                    dataset_id = '{dataset_id}';"""
         await connection.execute(q)
 
     return web.json_response({"message": "created"})
@@ -128,7 +131,10 @@ async def resource_updated(request):
             q = f"""
                     INSERT INTO catalog (dataset_id, resource_id, url, deleted, priority)
                     VALUES ('{dataset_id}', '{resource_id}', '{resource["url"]}', FALSE, TRUE)
-                    ON CONFLICT (dataset_id, resource_id, url) DO UPDATE SET priority = TRUE;"""
+                    ON CONFLICT (resource_id) DO UPDATE SET
+                        priority = TRUE,
+                        url = '{resource["url"]}',
+                        dataset_id = '{dataset_id}';"""
         await connection.execute(q)
 
     return web.json_response({"message": "updated"})

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -85,7 +85,10 @@ async def load_catalog(url=None, drop_meta=False, drop_all=False):
                         deleted, priority
                     )
                     VALUES ($1, $2, $3, $4, FALSE, FALSE)
-                    ON CONFLICT (dataset_id, resource_id, url) DO UPDATE SET deleted = FALSE
+                    ON CONFLICT (resource_id) DO UPDATE SET
+                        dataset_id = $1,
+                        url = $3,
+                        deleted = FALSE;
                 """,
                     row["dataset.id"],
                     row["id"],

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -30,7 +30,7 @@ NO_BACKOFF_DOMAINS = [
 # max number of _completed_ requests per domain per period
 BACKOFF_NB_REQ = 180
 BACKOFF_PERIOD = 360  # in seconds
-COOL_OFF_PERIOD = 86400 # 1 day to cool off when we've messed up
+COOL_OFF_PERIOD = 86400  # 1 day to cool off when we've messed up
 
 # crawl batch size, beware of open file limits
 # ⚠️ do not exceed MAX_POOL_SIZE

--- a/udata_hydra/migrations/main/20230606_rev9_up_rev10.sql
+++ b/udata_hydra/migrations/main/20230606_rev9_up_rev10.sql
@@ -1,0 +1,10 @@
+-- Apply unique constraint on resource_id instead of the tuple (dataset_id, resource_id, url)
+
+-- Drop duplicate entries for a resource_id, keeping the latest created one
+DELETE FROM catalog WHERE id IN (
+    SELECT a.id FROM catalog a, catalog b WHERE a.id < b.id and a.resource_id = b.resource_id
+);
+
+ALTER TABLE catalog
+    DROP CONSTRAINT catalog_dataset_id_resource_id_url_key,
+    ADD UNIQUE (resource_id);


### PR DESCRIPTION
Fix https://github.com/etalab/udata-hydra/issues/74

Add a constraint on resource_id unique, instead of the tuple (dataset_id, resource_id, url).
It means that on any resource update, we update URL value accordingly.
Past URLs that have been checked are kept in the `checks` table, thus keeping a trace of previous checked URLs if needed.
We also update the `purge_csv_tables` logic, that was expecting outdated URLs to be marked as deleted in the catalog.
But we can actually have URLs that disappear from the catalog, updated to the latest URL used for this resource.

Add unit test to describe buggy behavior
* There is one test on the load_catalog logic that creates multiple entries for a single resource
* And another test to raise a 500 on api udpate in case of multiple resource entries
* Add a test case on purge_csv_tables with url not in catalog anymore