### PR TITLE
Set check:available to None in case of a 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Support having multiple crawlers by setting a status column in the catalog table [#68](https://github.com/etalab/udata-hydra/pull/68)
 - Add a health route [#69](https://github.com/etalab/udata-hydra/pull/69)
 - Make temporary folder configurable [#70](https://github.com/etalab/udata-hydra/pull/70)
+- Set check:available to None in case of a 429 [#75](https://github.com/etalab/udata-hydra/pull/75)
 
 ## 1.0.1 (2023-01-04)
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock
 
 import nest_asyncio
 
-from aiohttp import ClientSession
-from aiohttp.client_exceptions import ClientError
+from aiohttp import ClientSession, RequestInfo
+from aiohttp.client_exceptions import ClientError, ClientResponseError
 from aioresponses import CallbackResult
 from asyncio.exceptions import TimeoutError
 from dateparser import parse as date_parser
@@ -134,6 +134,8 @@ async def test_catalog_deleted_with_new_url(setup_catalog, db, rmock, event_loop
         (None, False, AssertionError),
         (None, False, UnicodeError),
         (None, True, TimeoutError),
+        (429, False, ClientResponseError(RequestInfo(url="", method="", headers={}),
+                                         history=(), message="client error", status=429)),
     ],
 )
 async def test_crawl(setup_catalog, rmock, event_loop, db, resource, analysis_mock, udata_url):
@@ -175,7 +177,12 @@ async def test_crawl(setup_catalog, rmock, event_loop, db, resource, analysis_mo
     assert webhook.get("check:date")
     datetime.fromisoformat(webhook["check:date"])
     if exception or status == 500:
-        assert webhook.get("check:available") is False
+        if status == 429:
+            # In the case of a 429 status code, the error is on the crawler side and we can't give an availability status.
+            # We expect check:available to be None.
+            assert webhook.get("check:available") is None
+        else:
+            assert webhook.get("check:available") is False
     else:
         assert webhook.get("check:available")
         assert webhook.get("check:headers:content-type") == "application/json"

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -178,8 +178,8 @@ async def test_crawl(setup_catalog, rmock, event_loop, db, resource, analysis_mo
     datetime.fromisoformat(webhook["check:date"])
     if exception or status == 500:
         if status == 429:
-            # In the case of a 429 status code, the error is on the crawler side and we can't give an availability status.
-            # We expect check:available to be None.
+            # In the case of a 429 status code, the error is on the crawler side and we can't give an
+            # availability status. We expect check:available to be None.
             assert webhook.get("check:available") is None
         else:
             assert webhook.get("check:available") is False

--- a/udata_hydra/crawl.py
+++ b/udata_hydra/crawl.py
@@ -32,6 +32,9 @@ def is_valid_status(status):
     if not status:
         return False
     status = int(status)
+    if status == 429:
+        # We can't say the status since it's our client's fault
+        return None
     return status >= 200 and status < 400
 
 


### PR DESCRIPTION
We don't want to mark resources as unavailable on a 429 status code since it's the crawler's fault.
Setting check:available to None will override any existing values in extras. We should use this key to check the resource availability in the front.

See https://github.com/etalab/data.gouv.fr/issues/1092