### PR TITLE
Use latest csv-detective version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -291,35 +291,6 @@ tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900
 tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
-name = "backports-zoneinfo"
-version = "0.2.1"
-description = "Backport of the standard library zoneinfo module"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
-    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
-]
-
-[package.extras]
-tzdata = ["tzdata"]
-
-[[package]]
 name = "boto3"
 version = "1.26.28"
 description = "The AWS SDK for Python"
@@ -487,13 +458,13 @@ cron = ["capturer (>=2.4)"]
 
 [[package]]
 name = "csv-detective"
-version = "0.6.3"
+version = "0.6.4.dev390"
 description = "Detect CSV column content"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "csv_detective-0.6.3-py3-none-any.whl", hash = "sha256:65ca2c226bac872f1cb0c1da876ecdc2b7849221f54a4e7794451227cdf114d9"},
+    {file = "csv_detective-0.6.4.dev390-py3-none-any.whl", hash = "sha256:693261f7428fc08624355b41a0d500a4a2710eb8f1debbb56c35ccbf7f0dcc6d"},
 ]
 
 [package.dependencies]
@@ -1274,7 +1245,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = "*", markers = "python_version >= \"3.6\" and python_version < \"3.9\""}
 tzdata = {version = "*", markers = "python_version >= \"3.6\""}
 
 [[package]]
@@ -1653,7 +1623,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 pytz-deprecation-shim = "*"
 tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 
@@ -1795,5 +1764,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "4afd607c602a3844c07877d6839d16922d3cea82893c305e20e07a78763b641f"
+python-versions = "^3.9"
+content-hash = "06458b511556f6e8b4ec4935fe8cde4eae6e0987badd7c2ac53b3c426c98aeaa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ str2bool = "^1.1"
 sqlalchemy = "^1.4.46"
 dateparser = "^1.1.7"
 python-dateutil = "^2.8.2"
-csv-detective = "^0.6.3"
+csv-detective = "0.6.4.dev395"
 
 [tool.poetry.group.dev.dependencies]
 flake8-quotes = "^3.3.1"


### PR DESCRIPTION
We're not releasing csv-detective yet since there may be other parsing exceptions to fix shortly.

Some of cases that should be fix with the upgrade:
* [sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/2332/events/ae86d796cc934aa0978f62ed8e194684/?project=21&referrer=events-table%3Fproject%3D21) on the following csv: https://static.data.gouv.fr/resources/qualite-des-reseaux-ftth/20230612-153836/ftth-qualite-service.csv
* [sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/2332/events/86afd3843478401c981b7aae70efde68/?project=21&referrer=events-table%2F%3Fproject%3D2) on the following csv: https://download.data.grandlyon.com/ws/rdata/pvo_patrimoine_voirie.pvocameracriter/all.csv