### PR TITLE
Fix last_check_headers when  headers is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@
 - Make temporary folder configurable [#70](https://github.com/etalab/udata-hydra/pull/70)
 - Fix conflict on updating catalog with multiple entries for a resource [#73](https://github.com/etalab/udata-hydra/pull/73)
 - Set check:available to None in case of a 429 [#75](https://github.com/etalab/udata-hydra/pull/75)
-- Compare content type / length to check if changed [#78](https://github.com/etalab/udata-hydra/pull/78)
+- Improve conditional analysis logic and readability [#76](https://github.com/etalab/udata-hydra/pull/76)
+- Use latest csv-detective version [#77](https://github.com/etalab/udata-hydra/pull/77)
+- Compare content type / length to check if changed [#78](https://github.com/etalab/udata-hydra/pull/78) [#79](https://github.com/etalab/udata-hydra/pull/79)
+
 
 ## 1.0.1 (2023-01-04)
 

--- a/udata_hydra/crawl.py
+++ b/udata_hydra/crawl.py
@@ -64,7 +64,7 @@ async def compute_check_has_changed(check_data, last_check) -> bool:
     )
     timeout_has_changed = last_check and check_data.get("timeout") != last_check.get("timeout")
     current_headers = check_data.get("headers", {})
-    last_check_headers = json.loads(last_check.get("headers", {})) if last_check else None
+    last_check_headers = json.loads(last_check.get("headers")) if last_check and last_check.get("headers") else {}
     content_has_changed = (
         last_check
         and (current_headers.get("content-length") != last_check_headers.get("content-length")


### PR DESCRIPTION
See https://errors.data.gouv.fr/organizations/sentry/issues/3980/?alert_rule_id=2&alert_timestamp=1692701389542&alert_type=email&environment=production&project=2&referrer=alert_email.
`last_check` could have `headers` set to `None`, leading `json.loads(None)` to fail. We improve the `if` condition to ensure it isn't `None`.