### PR TITLE
Fix headers select query

### DIFF
--- a/udata_hydra/analysis/resource.py
+++ b/udata_hydra/analysis/resource.py
@@ -195,11 +195,11 @@ async def detect_resource_change_on_early_hints(resource_id: str) -> Tuple[Chang
     q = """
     SELECT
         created_at,
-        checks.headers->>'last-modified' as last_modified,
-        checks.headers->>'content-length' as content_length,
+        headers->>'last-modified' as last_modified,
+        headers->>'content-length' as content_length,
         detected_last_modified_at
-    FROM checks, catalog
-    WHERE checks.resource_id = $1
+    FROM checks
+    WHERE resource_id = $1
     ORDER BY created_at DESC
     LIMIT 2
     """


### PR DESCRIPTION
Fix following https://github.com/etalab/udata-hydra/pull/76.

Having `FROM checks, catalog` without having a junction `WHERE` clause led to the same checks being returned multiple times. We actually don't need catalog anymore in this request.
