### PR TITLE
Add worker default timeout config

### DIFF
--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -51,6 +51,9 @@ MAX_FILESIZE_ALLOWED = 104857600
 CSV_ANALYSIS_ENABLED = true
 TEMPORARY_DOWNLOAD_FOLDER = ""
 
+# -- Worker settings -- #
+RQ_DEFAULT_TIMEOUT = 180
+
 # -- Webhook integration config -- #
 WEBHOOK_ENABLED = true
 UDATA_URI = ""

--- a/udata_hydra/context.py
+++ b/udata_hydra/context.py
@@ -47,5 +47,5 @@ def queue(name="default"):
         if config.TESTING:
             return None
         connection = redis.from_url(config.REDIS_URL)
-        context["queues"][name] = Queue(name, connection=connection)
+        context["queues"][name] = Queue(name, connection=connection, default_timeout=config.RQ_DEFAULT_TIMEOUT)
     return context["queues"][name]


### PR DESCRIPTION
We may need to use a different default timeout for csv-to-db jobs, due to poor performances in csv-detective : https://github.com/etalab/csv-detective/issues/68.
Hopefully, we should be able to keep the default timeout in the long run.