### PR TITLE
Return None value early in csv-to-db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Create a list of exceptions to analyse despite larger size [#85](https://github.com/etalab/udata-hydra/pull/85)
 - Enable csv.gz analysis [#84](https://github.com/etalab/udata-hydra/pull/84)
 - Add worker default timeout config [#86](https://github.com/etalab/udata-hydra/pull/86)
-
+- Return None value early when casting in csv analysis [#87](https://github.com/etalab/udata-hydra/pull/87)
 
 ## 1.0.1 (2023-01-04)
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Install udata-hydra dependencies and cli.
 
 ### Load (UPSERT) latest catalog version from data.gouv.fr
 
-`udata-hydra load-catalog`
+`poetry run udata-hydra load-catalog`
 
 ## Crawler
 
-`udata-hydra-crawl`
+`poetry run udata-hydra-crawl`
 
 It will crawl (forever) the catalog according to config set in `config.py`.
 

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -115,6 +115,8 @@ def generate_dialect(inspection: dict) -> stdcsv.Dialect:
 
 def smart_cast(_type, value, failsafe=False) -> Any:
     try:
+        if value is None or value == "":
+            return None
         if _type == "bool":
             return str2bool(value)
         return PYTHON_TYPE_TO_PY[_type](value)


### PR DESCRIPTION
Returns early with None when converting empty values to int, float, etc.

Currently, `smart_cast` first fails when trying `int("")`, then we try to `str2float("" default=None)`, and finally return None.
It ends up logging lots of errors:
```
WARNING Could not convert "" to int, defaulting to null
```
We also gain significant time (from ~30 to ~20 seconds on big file test): https://github.com/etalab/udata-hydra/blob/1a1361e68055f2a12df640a35b4c9e777298b38b/tests/test_csv_analysis.py#L41

[Related error](https://errors.data.gouv.fr/organizations/sentry/issues/4169/?project=21&query=&referrer=issue-stream&statsPeriod=14d#breadcrumbs) (that failed due to task timeout).