### PR TITLE
Ignore deleted status when getting check by id

### DIFF
--- a/udata_hydra/utils/db.py
+++ b/udata_hydra/utils/db.py
@@ -67,8 +67,7 @@ async def get_check(check_id):
         q = """
             SELECT * FROM catalog JOIN checks
             ON catalog.last_check = checks.id
-            WHERE checks.id = $1
-            AND catalog.deleted = FALSE;
+            WHERE checks.id = $1;
         """
         check = await connection.fetchrow(q, check_id)
     return check


### PR DESCRIPTION
Indeed, when loading catalog, all datasets are temporarily set to deleted=true. Fetching checks at this moment returns None.
It raises a "Check not found by id" error in process_resource.

Fix https://errors.data.gouv.fr/organizations/sentry/issues/2359