### PR TITLE
Allow for none value in resource schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add worker default timeout config [#86](https://github.com/etalab/udata-hydra/pull/86)
 - Return None value early when casting in csv analysis [#87](https://github.com/etalab/udata-hydra/pull/87)
 - Ping udata after loading a csv to database [#91](https://github.com/etalab/udata-hydra/pull/91)
+- Allow for none value in resource schema [#93](https://github.com/etalab/udata-hydra/pull/93)
 
 ## 1.0.1 (2023-01-04)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,7 @@ def udata_resource_payload():
             "filetype": "file",
             "type": "documentation",
             "mime": "text/plain",
+            "schema": None,
             "filesize": 1024,
             "checksum_type": "sha1",
             "checksum_value": "b7b1cd8230881b18b6b487d550039949867ec7c5",

--- a/udata_hydra/app.py
+++ b/udata_hydra/app.py
@@ -46,7 +46,7 @@ class ResourceDocument(Schema):
     url = fields.Str(required=True)
     format = fields.Str(allow_none=True)
     title = fields.Str(required=True)
-    schema = fields.Dict()
+    schema = fields.Dict(allow_none=True)
     description = fields.Str(allow_none=True)
     filetype = fields.Str(required=True)
     type = fields.Str(required=True)


### PR DESCRIPTION
Fix 404 bad request on resource created or updated call. See [sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/2355/events/38a5e0eb55ec423ba5be55339d46e2bc/?project=12&referrer=events-table%2F%3Fproject%3D12).

Indeed, following https://github.com/opendatateam/udata/pull/2949 schema is set to None instead of an empty dict if not set.